### PR TITLE
Rlinq/version dependent settings

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -31,6 +31,23 @@
 
     Release notes:
 
+    2022.2.3 Set current Splunk Enterprise version so that group_vars files can use it.
+             Updated deployment_server group_vars file, if current Splunk Enterprise
+             version is below 9.0.0, disable deployment server functionallity.
+
+             Bug fixes:
+                * Corrected splunk_conf_group_settings variable in 
+                  templates/infrastructure_template/environments/ENVIRONMENT_NAME/group_vars/
+                  for
+                     all_in_one_servers
+	             data_collection_nodes
+	             deployment_servers
+	             forwarders
+	             hybrid_searchheads
+                  Important: Copy these files to your environments/ENVIRONMENT_NAME/group_vars
+                             folder if you have already run the setup. If not, you don't need to
+                             do anything.
+
     2022.2.2 Playbooks to manage Splunk Enterprise upgrades and CVE info
              Splunk Deployment Servers with a versions earlier than 9.0 has
              the following CVE-2022-32158, CVSSv3.1 Score: 9.0, Critical

--- a/cca_ctrl
+++ b/cca_ctrl
@@ -68,7 +68,7 @@ else
 fi
 
 WhiptailHight=30
-BackTitle="   $(hostname -s) - CCA for Splunk $(date +'%Y') v2022.2.2"
+BackTitle="   $(hostname -s) - CCA for Splunk $(date +'%Y') v2022.2.3"
 CookieFile="${ScriptPath}/.cookie"
 LicenseFile="${ScriptPath}/../${CcaRepo}/LICENSE"
 InfoFile="${ScriptPath}/../${CcaRepo}/RELEASE_NOTES.txt"

--- a/roles/cca.core.splunk/tasks/get_splunk_version.yml
+++ b/roles/cca.core.splunk/tasks/get_splunk_version.yml
@@ -1,0 +1,28 @@
+---
+# tasks file for cca.core.splunk
+#
+# Description:
+#
+# Prerequisite:
+#
+# Author: Roger Lindquist (github.com/rlinq)
+#
+# Release: 2022.2.3
+
+- name: Check if splunk is running by examine pid file
+  ansible.builtin.stat:
+    path: "{{ splunk_path }}/var/run/splunk/splunkd.pid"
+  register: stat_splunk_pid
+
+- name: Check current installed splunk version
+  ansible.builtin.shell:
+    cmd: "timeout 10 {{ splunk_path }}/bin/splunk version --accept-license --answer-yes --no-prompt | awk '{ print $2 }'"
+  register: splunk_enterprise_version_result
+  when:
+    - stat_splunk_pid.stat.exists
+  changed_when: false
+  check_mode: false
+
+- name: Set fact for current Splunk version or target splunk version of splunk is not running
+  ansible.builtin.set_fact:
+    current_splunk_enterprise_version: "{{ splunk_enterprise_version_result.stdout | default(splunk_enterprise_version) }}"

--- a/roles/cca.core.splunk/tasks/main.yml
+++ b/roles/cca.core.splunk/tasks/main.yml
@@ -12,8 +12,8 @@
 # Prerequisite:
 #
 # Roger Lindquist (github.com/rlinq)
-# META_DATE
-# META_VERSION
+#
+# Release: 2022.2.3
 - name: Include task for checking cca_for_splunk init state
   include_tasks: check_init.yml
 
@@ -25,6 +25,9 @@
 
 - name: Include task for checking certificate status
   include_tasks: ../../cca.splunk.ssl-certificates/tasks/validate_certificates.yml
+
+- name: Include task to calculate splunk enterprise version
+  include_tasks: get_splunk_version.yml
 
 - name: Run a precheck of the config to find errors
   include_tasks: precheck_settings.yml

--- a/templates/infrastructure_template/cca_ctrl
+++ b/templates/infrastructure_template/cca_ctrl
@@ -68,7 +68,7 @@ else
 fi
 
 WhiptailHight=30
-BackTitle="   $(hostname -s) - CCA for Splunk $(date +'%Y') v2022.2.2"
+BackTitle="   $(hostname -s) - CCA for Splunk $(date +'%Y') v2022.2.3"
 CookieFile="${ScriptPath}/.cookie"
 LicenseFile="${ScriptPath}/../${CcaRepo}/LICENSE"
 InfoFile="${ScriptPath}/../${CcaRepo}/RELEASE_NOTES.txt"

--- a/templates/infrastructure_template/environments/ENVIRONMENT_NAME/group_vars/all_in_one_servers
+++ b/templates/infrastructure_template/environments/ENVIRONMENT_NAME/group_vars/all_in_one_servers
@@ -3,7 +3,7 @@
 # group_vars/all/general_settings. Review those settings before applying
 # additional settings here.
 
-splunk_group_conf_settings:
+splunk_conf_group_settings:
 
  - name: Splunk server.conf
    filename: server.conf

--- a/templates/infrastructure_template/environments/ENVIRONMENT_NAME/group_vars/data_collection_nodes
+++ b/templates/infrastructure_template/environments/ENVIRONMENT_NAME/group_vars/data_collection_nodes
@@ -3,7 +3,7 @@
 # group_vars/all/general_settings. Review those settings before applying
 # additional settings here.
 
-splunk_group_conf_settings:
+splunk_conf_group_settings:
 
  - name: Splunk server.conf
    filename: server.conf

--- a/templates/infrastructure_template/environments/ENVIRONMENT_NAME/group_vars/deployment_servers
+++ b/templates/infrastructure_template/environments/ENVIRONMENT_NAME/group_vars/deployment_servers
@@ -3,7 +3,7 @@
 # group_vars/all/general_settings. Review those settings before applying
 # additional settings here.
 
-splunk_group_conf_settings:
+splunk_conf_group_settings:
 
  - name: Splunk serverclass.conf for deployment servers
    filename: serverclass.conf
@@ -13,6 +13,18 @@ splunk_group_conf_settings:
        options:
          - option: 'crossServerChecksum'
            value: 'true'
+         - option: 'disbled'
+           value: "{{ 'true'
+                      if
+                         current_splunk_enterprise_version is version('9.0.0', '<')
+                      else
+                       'false'
+                   }}"
+           comment: >-
+             Disables Deployment Server functionality if Splunk Enterprise runs on a version
+             prior to 9.0.0. Vulnerability description at Splunk.
+             https://www.splunk.com/en_us/product-security/announcements/svd-2022-0608.html
+
 
  - name: Splunk server.conf
    filename: server.conf

--- a/templates/infrastructure_template/environments/ENVIRONMENT_NAME/group_vars/forwarders
+++ b/templates/infrastructure_template/environments/ENVIRONMENT_NAME/group_vars/forwarders
@@ -3,7 +3,7 @@
 # group_vars/all/general_settings. Review those settings before applying
 # additional settings here.
 
-splunk_group_conf_settings:
+splunk_conf_group_settings:
 
  - name: Splunk server.conf
    filename: server.conf

--- a/templates/infrastructure_template/environments/ENVIRONMENT_NAME/group_vars/hybrid_searchheads
+++ b/templates/infrastructure_template/environments/ENVIRONMENT_NAME/group_vars/hybrid_searchheads
@@ -3,7 +3,7 @@
 # group_vars/all/general_settings. Review those settings before applying
 # additional settings here.
 
-splunk_group_conf_settings:
+splunk_conf_group_settings:
 
  - name: Splunk server.conf
    filename: server.conf

--- a/templates/onboarding_template/cca_ctrl
+++ b/templates/onboarding_template/cca_ctrl
@@ -68,7 +68,7 @@ else
 fi
 
 WhiptailHight=30
-BackTitle="   $(hostname -s) - CCA for Splunk $(date +'%Y') v2022.2.2"
+BackTitle="   $(hostname -s) - CCA for Splunk $(date +'%Y') v2022.2.3"
 CookieFile="${ScriptPath}/.cookie"
 LicenseFile="${ScriptPath}/../${CcaRepo}/LICENSE"
 InfoFile="${ScriptPath}/../${CcaRepo}/RELEASE_NOTES.txt"


### PR DESCRIPTION
Updated deployment_server group_vars file, if current Splunk Enterprise
Set current Splunk Enterprise version so that group_vars files can use it.

Updated deployment_server group_vars file, if current Splunk Enterprise
version is below 9.0.0, disable deployment server functionallity.

   Bug fixes:
      * Corrected splunk_conf_group_settings variable in
        templates/infrastructure_template/environments/ENVIRONMENT_NAME/group_vars/
        for
           * all_in_one_servers
           * data_collection_nodes
           * deployment_servers
           * forwarders
           * hybrid_searchheads
        ***Important:*** Copy these files to your environments/ENVIRONMENT_NAME/group_vars
                   folder if you have already run the setup. If not, you don't need to
                   do anything.