### PR TITLE
Improvements for cgroup and kvstore upgrades

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -58,8 +58,7 @@
                    copy the cert-inspect.sh script from templates/infrastructure_template/splunk/etc/auth/certs
                    to your infrastructure directory and validate your certificates before deployment.
               - Full support for cgroups version 2. The upgrade is performed automatically when running
-                the rolling_update_linux_servers.yml or configure_linux_servers.yml playbooks after
-                upgrading to Splunk 9.4+.
+                the configure_linux_servers.yml playbooks after upgrading to Splunk 9.4+.
               - Added automatic handling of KVStore upgrades introduced in 9.4. The playbook will now
                 wait until the KVStore upgrade is completed. This process takes time as kvstore is upgraded
                 by splunk 3 times in the background. Do not set shc_upgrade_kvstore_engine to true for 9.4
@@ -73,6 +72,7 @@
                 templates/infrastructure_template/ENVIRONMENT_NAME/group_vars/cluster_manager_cluster_c1.
               - Improved the stability of the Splunk `offline` command on index peers. If a timeout occurs,
                 the system now performs a `splunk stop` as fallback.
+              - Improved Splunk Version handling during server reboot and cgroups configuration updates.
 
               Bug Fixes:
                 - Corrected splunk_conf_host_settings that was incorrectly referring splunk_conf_group_settings.

--- a/roles/cca.core.linux/handlers/main.yml
+++ b/roles/cca.core.linux/handlers/main.yml
@@ -2,6 +2,8 @@
 # handlers file for cca.core.linux
 #
 - name: Server reboot notification handler
+  become: true
+  become_method: sudo
   ansible.builtin.file:
     path: "{{ server_reboot_pending | default('/tmp/server_reboot.pending') }}"
     state: touch
@@ -18,6 +20,7 @@
   no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: Check if handler file exists (splunk service restart)
+  become: true
   ansible.builtin.stat:
     path: "{{ splunk_service_restart_pending | default('/tmp/splunk_service_restart.pending') }}"
   register: splunk_restart_pending_stat
@@ -26,6 +29,7 @@
   changed_when: false
 
 - name: Touch the file only if it does not already exist
+  become: true
   ansible.builtin.file:
     path: "{{ splunk_service_restart_pending | default('/tmp/splunk_service_restart.pending') }}"
     state: touch

--- a/roles/cca.core.linux/tasks/check_pending_actions.yml
+++ b/roles/cca.core.linux/tasks/check_pending_actions.yml
@@ -16,6 +16,7 @@
   ansible.builtin.command:
     cmd: hostname -s
   register: manager_hostname_result
+  changed_when: false
 
 - name: Set manager hostname fact
   delegate_to: localhost

--- a/roles/cca.core.linux/tasks/configure_splunk_service.yml
+++ b/roles/cca.core.linux/tasks/configure_splunk_service.yml
@@ -9,9 +9,14 @@
 #
 # Release: 2025.1.1
 
+- name: Gather facts about configured services
+  ansible.builtin.service_facts:
 
-- name: Get current Splunk Enterprise version
+- name: Get current Splunk Enterprise status
   include_tasks: ../../cca.core.splunk/tasks/get_splunk_status.yml
+  when:
+    - ansible_facts.services[systemd_enterprise_name] is defined
+    - ansible_facts.services[systemd_enterprise_name].state == "running"
 
 - name: Get current Splunk Enterprise version
   include_tasks: ../../cca.core.splunk/tasks/get_splunk_version.yml

--- a/roles/cca.core.linux/tasks/main.yml
+++ b/roles/cca.core.linux/tasks/main.yml
@@ -70,6 +70,11 @@
   when:
     - control.linux_configuration.splunk_limits | default(true)
 
+- name: Get splunk version
+  ansible.builtin.include_tasks: ../../cca.core.splunk/tasks/get_splunk_version.yml
+  when:
+    - control.linux_configuration.splunk_version | default(true)
+
 - name: Setup splunk service
   ansible.builtin.include_tasks: configure_splunk_service.yml
   when:

--- a/roles/cca.core.linux/tasks/server_reboot_handler.yml
+++ b/roles/cca.core.linux/tasks/server_reboot_handler.yml
@@ -14,10 +14,10 @@
   ansible.builtin.service_facts:
   no_log: "{{ ansible_verbosity < 3 }}"
 
-- name: Include role to check if there is a pending reboot
-  ansible.builtin.include_tasks: check_pending_actions.yml
+- name: Include tasks to handle cgroup versions, secondary reboot if needed
+  include_tasks: systemd/manage_cgroup_version.yml
   when:
-    - not cca_skip_server_reboot | default(false)
+    - not cgroups_configured | default(false)
 
 - name: Control services during server reboot and reboot server if required
   block:
@@ -61,30 +61,9 @@
         - server_reboot_status.rebooted
       check_mode: false
 
-    - name: Include tasks to handle cgroup versions, secondary reboot if needed
-      include_tasks: systemd/manage_cgroup_version.yml
-      when:
-        - not cgroups_configured | default(false)
-
     - name: Set fact that cgroups has been configured
       ansible.builtin.set_fact:
         cgroups_configured: true
-
-    - name: Delete statefile based on reboot status
-      ansible.builtin.file:
-        path: "{{ server_reboot_pending | default('/tmp/server_reboot.pending') }}"
-        state: 'absent'
-      when:
-        - server_reboot_status.rebooted
-      check_mode: false
-
-    - name: Delete statefile based on reboot status
-      ansible.builtin.file:
-        path: "{{ splunk_service_restart_pending | default('/tmp/splunk_service_restart.pending') }}"
-        state: 'absent'
-      when:
-        - server_reboot_status.rebooted
-      check_mode: false
 
   when:
     - stat_server_reboot_pending.stat.exists | default(false)
@@ -93,16 +72,6 @@
 - name: Gather facts about configured services
   ansible.builtin.service_facts:
   no_log: "{{ ansible_verbosity < 3 }}"
-
-- name: Start cgroup_daemon service and enable it
-  ansible.builtin.systemd:
-    name: cca_cgroup_version_daemon.service
-    state: started
-    enabled: true
-  when:
-    - ansible_facts.services['cca_cgroup_version_daemon.service'] is defined
-  no_log: "{{ ansible_verbosity < 3 }}"
-
 
 - name: Restart Splunkd service if it was started and require restart
   ansible.builtin.systemd:

--- a/roles/cca.core.linux/tasks/set_reboot_flag.yml
+++ b/roles/cca.core.linux/tasks/set_reboot_flag.yml
@@ -14,4 +14,5 @@
   ansible.builtin.file:
     path: "{{ server_reboot_pending | default('/tmp/server_reboot.pending') }}"
     state: touch
+    mode: '0644'
   check_mode: false

--- a/roles/cca.core.linux/tasks/systemd/main.yml
+++ b/roles/cca.core.linux/tasks/systemd/main.yml
@@ -11,8 +11,3 @@
 
 - name: Include tasks to handle cgroup versions
   include_tasks: systemd/manage_cgroup_version.yml
-
-- name: Include tasks for systemd setup
-  include_tasks: systemd/splunkd_service.yml
-  when:
-    - not upgrade_cgroup_version | default(false)

--- a/roles/cca.core.linux/tasks/systemd/manage_cgroup_v1.yml
+++ b/roles/cca.core.linux/tasks/systemd/manage_cgroup_v1.yml
@@ -26,6 +26,7 @@
   when:
     - ansible_distribution == 'Debian' or
       ansible_distribution == 'Ubuntu'
+    - running_kernel_cgroup_version | default('') != 'cgroupv1'
   notify: notify server reboot
 
 - name: Configure legacy cgroup version until Splunk supports cgroupv2
@@ -35,6 +36,7 @@
   when:
     - ansible_distribution != 'Debian'
     - ansible_distribution != 'Ubuntu'
+    - running_kernel_cgroup_version | default('') != 'cgroupv1'
   register: grubby_kernel_update_status
   notify: notify server reboot
 
@@ -52,9 +54,10 @@
     dest: "/etc/systemd/system/cca_cgroup_version_daemon.service"
     mode: '0644'
 
+- name: Include role to configure splunk service
+  ansible.builtin.include_tasks: systemd/splunkd_service.yml
+  vars:
+    configure_cgroup_version: cgroupv1
+
 - name: Trigger restart if pending from cgroups update
   meta: flush_handlers
-
-- name: Include role for reboot handler
-  ansible.builtin.include_tasks:
-    file: server_reboot_handler.yml

--- a/roles/cca.core.linux/tasks/systemd/manage_cgroup_v2.yml
+++ b/roles/cca.core.linux/tasks/systemd/manage_cgroup_v2.yml
@@ -23,7 +23,7 @@
     path: "/etc/systemd/system/cca_cgroup_version_daemon.service"
     state: absent
 
-- name: Revert cgroup setting in /etc/default/grub (Debian-based systems)
+- name: Restore cgroup v2 setting in /etc/default/grub (Debian-based systems)
   ansible.builtin.lineinfile:
     path: /etc/default/grub
     regexp: '^(GRUB_CMDLINE_LINUX=".*)(\s*systemd.unified_cgroup_hierarchy=0)(.*)"$'
@@ -42,7 +42,7 @@
     - ansible_distribution in ['Debian', 'Ubuntu']
     - debian_grub_revert_status.changed
 
-- name: Revert cgroup setting with grubby (non-Debian systems)
+- name: Restore cgroup v2 setting with grubby (non-Debian systems)
   ansible.builtin.command: >
     grubby --update-kernel=ALL --remove-args="systemd.unified_cgroup_hierarchy=0"
   register: grubby_kernel_revert_status
@@ -52,36 +52,10 @@
     - running_kernel_cgroup_version == 'cgroupv1'
     - supported_kernel_cgroup_version == 'cgroupv2'
 
-- name: Configure splunk service in /etc/systemd/system/{{ systemd_enterprise_name }}
-  ansible.builtin.template:
-    src: "etc/systemd/system/{{ systemd_enterprise_name }}_{{ supported_kernel_cgroup_version }}.j2"
-    dest: "/etc/systemd/system/{{ systemd_enterprise_name }}"
-    mode: '0644'
-  notify: notify restart splunkd service
-
-- name: Ensure the destination directory exists
-  ansible.builtin.file:
-    path: "/etc/systemd/system/{{ systemd_enterprise_name }}.d"
-    state: directory
-    mode: '0755'
-
-- name: Configure splunk service limits in /etc/systemd/system/{{ systemd_enterprise_name }}.d/limits.conf
-  ansible.builtin.template:
-    src: "etc/systemd/system/{{ systemd_enterprise_name }}.d/limits.conf_{{ supported_kernel_cgroup_version }}.j2"
-    dest: "/etc/systemd/system/{{ systemd_enterprise_name }}.d/limits.conf"
-    mode: '0644'
-  notify: notify restart splunkd service
-
-- name: Configure systemd for the new Splunkd service
-  ansible.builtin.systemd:
-    name: "{{ systemd_enterprise_name }}"
-    enabled: true
-    daemon_reload: true
-  no_log: "{{ ansible_verbosity < 3 }}"
+- name: Include role to configure splunk service
+  ansible.builtin.include_tasks: systemd/splunkd_service.yml
+  vars:
+    configure_cgroup_version: cgroupv2
 
 - name: Trigger restart if pending from cgroups update
-  ansible.builtin.meta: flush_handlers
-
-- name: Include role for reboot handler
-  ansible.builtin.include_tasks:
-    file: server_reboot_handler.yml
+  meta: flush_handlers

--- a/roles/cca.core.linux/tasks/systemd/manage_cgroup_version.yml
+++ b/roles/cca.core.linux/tasks/systemd/manage_cgroup_version.yml
@@ -5,10 +5,12 @@
 #
 # Prerequisite:
 #
-# Roger Lindquist (github.com/rlinq)
+# Author: Roger Lindquist (github.com/rlinq)
 #
 # Release: 2025.1.1
 
+- name: Get Splunk Enterprise version
+  ansible.builtin.include_tasks: ../../cca.core.splunk/tasks/get_splunk_version.yml
 
 - name: Get running cgroup version
   ansible.builtin.command:
@@ -46,30 +48,39 @@
   ansible.builtin.set_fact:
     current_systemd_cgroup_version: "{{ 'cgroupv1' if systemd_cgroup_version_result.stdout | int == 1 else 'cgroupv2' }}"
 
-- name: Include task to configure cgroupv1
-  ansible.builtin.include_tasks: manage_cgroup_v1.yml
-  when:
-    - running_kernel_cgroup_version != 'cgroupv1'
-    - current_systemd_cgroup_version != 'cgroupv1'
-    - (
-        (splunk_enterprise_is_installed | default(false)) and
-        (current_splunk_enterprise_version is version('9.4.0', '<'))
-      ) or
-      (
-        (not splunk_enterprise_is_installed | default(false)) and
-        (splunk_enterprise_version is version('9.4.0', '<'))
-      )
+- name: Set Splunk version compatibility
+  ansible.builtin.set_fact:
+    splunk_supports_cgroupv2: "{{ current_splunk_enterprise_version is version('9.4.0', '>=') }}"
 
-- name: Include task to configure cgroupv2
-  ansible.builtin.include_tasks: manage_cgroup_v2.yml
+- name: Configure cgroup version based on Splunk version and current state
+  block:
+    - name: Configure cgroup v1 for Splunk versions below 9.4.0
+      block:
+        - name: Include tasks for configuring cgroup v1
+          ansible.builtin.include_tasks: systemd/manage_cgroup_v1.yml
+
+        - name: Set fact that cgroups has been configured
+          ansible.builtin.set_fact:
+            cgroups_configured: true
+
+      when:
+        - not splunk_supports_cgroupv2
+        - running_kernel_cgroup_version == 'cgroupv1'
+
+    - name: Configure cgroup v2 for Splunk versions 9.4.0 and above
+      block:
+        - name: Include tasks for configuring cgroup v2
+          ansible.builtin.include_tasks: systemd/manage_cgroup_v2.yml
+
+        - name: Set fact that cgroups has been configured
+          ansible.builtin.set_fact:
+            cgroups_configured: true
+
+      when:
+        - splunk_supports_cgroupv2
+        - (running_kernel_cgroup_version == 'cgroupv2' or supported_kernel_cgroup_version == 'cgroupv2')
+
+- name: Include role to check if there is a pending reboot
+  ansible.builtin.include_tasks: check_pending_actions.yml
   when:
-    - running_kernel_cgroup_version == 'cgroupv2' or
-      supported_kernel_cgroup_version == 'cgroupv2'
-    - (
-        (splunk_enterprise_is_installed | default(false)) and
-        (current_splunk_enterprise_version is version('9.4.0', '>='))
-      ) or
-      (
-        (not splunk_enterprise_is_installed | default(false)) and
-        (splunk_enterprise_version is version('9.4.0', '>='))
-      )
+    - not cca_skip_server_reboot | default(false)

--- a/roles/cca.core.linux/tasks/systemd/splunkd_service.yml
+++ b/roles/cca.core.linux/tasks/systemd/splunkd_service.yml
@@ -12,9 +12,10 @@
 
 - name: Configure splunk service in /etc/systemd/system/{{ systemd_enterprise_name }}
   ansible.builtin.template:
-    src: "etc/systemd/system/{{ systemd_enterprise_name }}_{{ running_kernel_cgroup_version }}.j2"
+    src: "etc/systemd/system/{{ systemd_enterprise_name }}_{{ configure_cgroup_version }}.j2"
     dest: "/etc/systemd/system/{{ systemd_enterprise_name }}"
     mode: '0644'
+  register: systemd_service_result
   notify: notify restart splunkd service
 
 - name: Ensure the destination directory exists
@@ -25,9 +26,10 @@
 
 - name: Configure splunk service limits in /etc/systemd/system/{{ systemd_enterprise_name }}.d/limits.conf
   ansible.builtin.template:
-    src: "etc/systemd/system/{{ systemd_enterprise_name }}.d/limits.conf_{{ running_kernel_cgroup_version }}.j2"
+    src: "etc/systemd/system/{{ systemd_enterprise_name }}.d/limits.conf_{{ configure_cgroup_version }}.j2"
     dest: "/etc/systemd/system/{{ systemd_enterprise_name }}.d/limits.conf"
     mode: '0644'
+  register: systemd_limits_result
   notify: notify restart splunkd service
 
 - name: Configure systemd for the new Splunkd service
@@ -37,4 +39,6 @@
     daemon_reload: true
   no_log: "{{ ansible_verbosity < 3 }}"
   when:
-    - not server_reboot_status.rebooted | default(false)
+    - not server_reboot_status.rebooted | default(false) or
+      systemd_service_result.changed or
+      systemd_limits_result.changed

--- a/roles/cca.core.splunk/tasks/cluster/get_cluster_status.yml
+++ b/roles/cca.core.splunk/tasks/cluster/get_cluster_status.yml
@@ -24,6 +24,22 @@
   ansible.builtin.set_fact:
     current_splunk_enterprise_version: "{{ cluster_peer_splunk_version.stdout_lines[0] | trim }}"
 
+- name: Create directory for splunk version file if it doesn't exist
+  ansible.builtin.file:
+    path: "{{ splunk_version_file | default(splunk_path ~ '/.cca/splunk_version') | dirname }}"
+    owner: "{{ splunk_user }}"
+    group: "{{ splunk_user_group_name }}"
+    state: directory
+    mode: '0755'
+
+- name: Store Splunk version
+  ansible.builtin.copy:
+    content: "{{ current_splunk_enterprise_version }}"
+    dest: "{{ splunk_version_file | default(splunk_path ~ '/.cca/splunk_version') }}"
+    owner: "{{ splunk_user }}"
+    group: "{{ splunk_user_group_name }}"
+    mode: '0644'
+
 - name: Collect full Index Cluster status
   ansible.builtin.command:
     cmd: "timeout 60 {{ splunk_path }}/bin/splunk show cluster-status --verbose"

--- a/roles/cca.core.splunk/tasks/get_splunk_status.yml
+++ b/roles/cca.core.splunk/tasks/get_splunk_status.yml
@@ -32,6 +32,7 @@
   changed_when: false
   when:
     - splunk_enterprise_is_installed
+    - not skip_splunk_status_check | default(false)
   check_mode: false
 
 - name: Set fact if expected splunk status is met
@@ -48,7 +49,8 @@
     fail_msg: >-
       Splunk status is not OK, this host will be skipped
   when:
-      - splunk_enterprise_is_installed
+    - splunk_enterprise_is_installed
+    - not skip_splunk_status_check | default(false)
 
 - name: Include task to get certificate status
   ansible.builtin.include_tasks:

--- a/roles/cca.core.splunk/tasks/get_splunk_version.yml
+++ b/roles/cca.core.splunk/tasks/get_splunk_version.yml
@@ -7,14 +7,14 @@
 #
 # Author: Roger Lindquist (github.com/rlinq)
 #
-# Release: 2023.2.1
+# Release: 2025.1.1
 
 - name: Check if splunk is running by examine pid file
   ansible.builtin.stat:
     path: "{{ splunk_path }}/var/run/splunk/splunkd.pid"
   register: stat_splunk_pid
 
-- name: Check current installed splunk version
+- name: Check current installed splunk version from running instance
   ansible.builtin.shell:
     cmd: >-
      timeout 10 {{ splunk_path }}/bin/splunk version --accept-license --answer-yes --no-prompt | grep -E "Splunk [0-9\.]+ \(build" | awk '{ print $2 }'
@@ -24,6 +24,49 @@
   changed_when: false
   check_mode: false
 
-- name: Set fact for current Splunk version or target splunk version if splunk is not running
+- name: Check for stored version file
+  ansible.builtin.stat:
+    path: "{{ splunk_version_file | default(splunk_path ~ '/.cca/splunk_version') }}"
+  register: splunk_version_file_stat
+  when:
+    - not stat_splunk_pid.stat.exists
+
+- name: Read stored Splunk version
+  ansible.builtin.slurp:
+    src: "{{ splunk_version_file | default(splunk_path ~ '/.cca/splunk_version') }}"
+  register: splunk_version_file_content
+  when:
+    - not stat_splunk_pid.stat.exists
+    - splunk_version_file_stat.stat.exists
+
+- name: Set fact for current Splunk version with fallback chain
   ansible.builtin.set_fact:
-    current_splunk_enterprise_version: "{{ splunk_enterprise_version_result.stdout | default(splunk_enterprise_version) }}"
+    current_splunk_enterprise_version: >-
+      {% if stat_splunk_pid.stat.exists and splunk_enterprise_version_result.stdout is defined and splunk_enterprise_version_result.stdout | trim != '' %}
+        {{ splunk_enterprise_version_result.stdout | trim }}
+      {% elif splunk_version_file_stat.stat.exists and splunk_version_file_content.content is defined and splunk_version_file_content.content | b64decode | trim != '' %}
+        {{ splunk_version_file_content.content | b64decode | trim }}
+      {% else %}
+        {{ splunk_enterprise_version | default('0.0.0') }}
+      {% endif %}
+
+- name: Create directory for splunk version file if it doesn't exist
+  ansible.builtin.file:
+    path: "{{ splunk_version_file | default(splunk_path ~ '/.cca/splunk_version') | dirname }}"
+    owner: "{{ splunk_user }}"
+    group: "{{ splunk_user_group_name }}"
+    state: directory
+    mode: '0755'
+
+- name: Store Splunk version
+  ansible.builtin.copy:
+    content: "{{ current_splunk_enterprise_version }}"
+    dest: "{{ splunk_version_file | default(splunk_path ~ '/.cca/splunk_version') }}"
+    owner: "{{ splunk_user }}"
+    group: "{{ splunk_user_group_name }}"
+    mode: '0644'
+
+- name: Ensure current_splunk_enterprise_version is a valid version string
+  ansible.builtin.set_fact:
+    current_splunk_enterprise_version: "{{ current_splunk_enterprise_version | regex_replace('^[^0-9]*([0-9]+\\.[0-9]+\\.[0-9]+).*$', '\\1') }}"
+  when: current_splunk_enterprise_version is defined

--- a/roles/cca.core.splunk/tasks/shcluster/get_shcluster_status.yml
+++ b/roles/cca.core.splunk/tasks/shcluster/get_shcluster_status.yml
@@ -27,6 +27,22 @@
   ansible.builtin.set_fact:
     current_splunk_enterprise_version: "{{ shcluster_splunk_version.stdout }}"
 
+- name: Create directory for splunk version file if it doesn't exist
+  ansible.builtin.file:
+    path: "{{ splunk_version_file | default(splunk_path ~ '/.cca/splunk_version') | dirname }}"
+    owner: "{{ splunk_user }}"
+    group: "{{ splunk_user_group_name }}"
+    state: directory
+    mode: '0755'
+
+- name: Store Splunk version
+  ansible.builtin.copy:
+    content: "{{ current_splunk_enterprise_version }}"
+    dest: "{{ splunk_version_file | default(splunk_path ~ '/.cca/splunk_version') }}"
+    owner: "{{ splunk_user }}"
+    group: "{{ splunk_user_group_name }}"
+    mode: '0644'
+
 - name: Get info of kvstore engine
   ansible.builtin.shell:
     cmd: |

--- a/roles/cca.core.splunk/tasks/shcluster/precheck_upgrade_status.yml
+++ b/roles/cca.core.splunk/tasks/shcluster/precheck_upgrade_status.yml
@@ -43,6 +43,7 @@
   register: mongod_version
   changed_when: false
   when: (current_splunk_enterprise_version | default(splunk_enterprise_version)) is version('9.4.0', '<')
+  check_mode: false
 
 - name: Assert MongoDB version matches expected KVStore engine version for Splunk >= 9.4.0
   ansible.builtin.assert:

--- a/roles/cca.core.splunk/tasks/splunk_login.yml
+++ b/roles/cca.core.splunk/tasks/splunk_login.yml
@@ -28,6 +28,8 @@
   delay: 10
   changed_when: false
   check_mode: false
+  when:
+    - not skip_splunk_status_check | default(false)
 
 - name: Splunk login
   ansible.builtin.command:
@@ -40,6 +42,8 @@
   failed_when: false
   changed_when: false
   check_mode: false
+  when:
+    - not skip_splunk_status_check | default(false)
 
 - name: Assert to find out if the login was successful
   ansible.builtin.assert:
@@ -53,3 +57,5 @@
       Return code ={{ splunk_login_result.rc }} )
     success_msg: >-
       Login successful
+  when:
+    - not skip_splunk_status_check | default(false)

--- a/roles/cca.splunk.enterprise-install/tasks/ensure_splunk_version.yml
+++ b/roles/cca.splunk.enterprise-install/tasks/ensure_splunk_version.yml
@@ -102,29 +102,7 @@
   when:
     - stat_splunk_enterprise_bin.stat.exists
 
-- name: Check if standalone-kvupgrade-status command is available
-  ansible.builtin.shell: "timeout 30 {{ splunk_path }}/bin/splunk help show | grep standalone-kvupgrade-status"
-  register: kv_command_check
-  ignore_errors: true
-  changed_when: false
+- name: Include task to check kvstore upgrade status
+  include_tasks: kvstore_upgrade_status.yml
   when:
-    - enterprise_upgrade | default(false)
-    - not ansible_check_mode
-  no_log: "{{ hide_password | default(false) }}"
-
-- name: Wait for KVStore upgrade to complete
-  ansible.builtin.shell: "timeout 30 {{ splunk_path }}/bin/splunk show standalone-kvupgrade-status"
-  register: kv_status
-  until: kv_status.stdout is search('Upgrade Status:\s+0')
-  retries: "{{ cca_splunk_kvstore_upgrade_retries | default(30) | int }}"
-  delay: "{{ cca_splunk_kvstore_upgrade_delay | default(60) | int }}"
-  changed_when: false
-  failed_when: 
-    - kv_status.stdout is not search('Upgrade Status:\s+0')
-    - "'is not a valid argument' not in kv_status.stderr"
-  when:
-    - enterprise_upgrade | default(false)
-    - not ansible_check_mode
-    - kv_command_check is defined
-    - kv_command_check.rc | default(0) == 0 
-    - kv_command_check.stdout | default('') != "" 
+    - stat_splunk_enterprise_bin.stat.exists

--- a/roles/cca.splunk.enterprise-install/tasks/kvstore_upgrade_status.yml
+++ b/roles/cca.splunk.enterprise-install/tasks/kvstore_upgrade_status.yml
@@ -1,0 +1,74 @@
+---
+# tasks file for cca.splunk.enterprise-install
+#
+# Description:
+#
+# Prerequisite:
+#
+# Author: Roger Lindquist (github.com/rlinq)
+#
+# Release: 2025.1.1
+
+- name: Include tasks to login to splunk cli
+  ansible.builtin.include_tasks: ../../cca.core.splunk/tasks/splunk_login.yml
+  when:
+    - enterprise_upgrade | default(false)
+
+- name: Check if kvstore is enabled
+  ansible.builtin.shell: "{{ splunk_path }}/bin/splunk show kvstore-status"
+  register: kvstore_status
+
+- name: Check if standalone-kvupgrade-status command is available
+  ansible.builtin.shell: "timeout 30 {{ splunk_path }}/bin/splunk help show | grep standalone-kvupgrade-status"
+  register: kv_command_check
+  ignore_errors: true
+  changed_when: false
+  retries: 5
+  delay: 30
+  until: kv_command_check.rc is defined and kv_command_check.rc == 0 or kv_command_check.rc == 1
+  when:
+    - enterprise_upgrade | default(false)
+    - not ansible_check_mode
+    - kvstore_status.stdout is search('status :')
+  no_log: "{{ hide_password | default(false) }}"
+
+
+- name: Wait for KVStore upgrade to complete
+  ansible.builtin.shell: "timeout 30 {{ splunk_path }}/bin/splunk show standalone-kvupgrade-status"
+  register: kv_status
+  until: >
+    kv_status.stdout is search('Upgrade Status:\s+0')
+  retries: "{{ cca_splunk_kvstore_upgrade_retries | default(75) | int }}"
+  delay: "{{ cca_splunk_kvstore_upgrade_delay | default(60) | int }}"
+  changed_when: false
+  failed_when: 
+    - kv_status.stdout is not search('Upgrade Status:\s+0')
+    - "'is not a valid argument' not in kv_status.stderr"
+  when:
+    - enterprise_upgrade | default(false)
+    - not ansible_check_mode
+    - kv_command_check is defined
+    - kv_command_check.rc | default(0) == 0 
+    - kv_command_check.stdout | default('') != ""
+    - kvstore_status.stdout is search('status :')
+  
+- name: Debug KVStore upgrade status
+  ansible.builtin.debug:
+    msg: "KVStore Upgrade Output: {{ kv_status.stdout }}"
+  when:
+    - enterprise_upgrade | default(false)
+    - not ansible_check_mode
+    - kv_command_check is defined
+    - kv_command_check.rc | default(0) == 0 
+    - kv_command_check.stdout | default('') != ""
+    - ansible_verbosity > 1
+    - kvstore_status.stdout is search('status :')
+
+- name: Include tasks to logout on splunk cli
+  ansible.builtin.include_tasks: ../../cca.core.splunk/tasks/splunk_logout.yml
+  when:
+    - enterprise_upgrade | default(false)
+    - not ansible_check_mode
+    - kv_command_check is defined
+    - kv_command_check.rc | default(0) == 0 
+    - kv_command_check.stdout | default('') != ""

--- a/roles/cca.splunk.enterprise-install/tasks/shcluster/finalize_upgrade.yml
+++ b/roles/cca.splunk.enterprise-install/tasks/shcluster/finalize_upgrade.yml
@@ -9,33 +9,15 @@
 #
 # Release: 2025.1.1
 
-
-- name: Check if standalone-kvupgrade-status command is available
-  ansible.builtin.shell: "timeout 30 {{ splunk_path }}/bin/splunk help show | grep standalone-kvupgrade-status"
-  register: kv_command_check
-  ignore_errors: true
-  changed_when: false
+- name: Include task to check kvstore upgrade status
+  include_tasks: kvstore_upgrade_status.yml
   when:
     - enterprise_upgrade | default(false)
-    - not ansible_check_mode
-  no_log: "{{ hide_password | default(false) }}"
 
-- name: Wait for KVStore upgrade to complete
-  ansible.builtin.shell: "timeout 30 {{ splunk_path }}/bin/splunk show standalone-kvupgrade-status"
-  register: kv_status
-  until: kv_status.stdout is search('Upgrade Status:\s+0')
-  retries: "{{ cca_splunk_kvstore_upgrade_retries | default(30) | int }}"
-  delay: "{{ cca_splunk_kvstore_upgrade_delay | default(60) | int }}"
-  changed_when: false
-  failed_when: 
-    - kv_status.stdout is not search('Upgrade Status:\s+0')
-    - "'is not a valid argument' not in kv_status.stderr"
+- name: Include tasks to login to splunk cli
+  ansible.builtin.include_tasks: ../../cca.core.splunk/tasks/splunk_login.yml
   when:
     - enterprise_upgrade | default(false)
-    - not ansible_check_mode
-    - kv_command_check is defined
-    - kv_command_check.rc | default(0) == 0 
-    - kv_command_check.stdout | default('') != "" 
 
 - name: Finalize rolling upgrade on a SHC member
   ansible.builtin.command:
@@ -48,3 +30,12 @@
   when:
     - enterprise_upgrade | default(false)
     - not ansible_check_mode
+
+- name: Include tasks to logout on splunk cli
+  ansible.builtin.include_tasks: ../../cca.core.splunk/tasks/splunk_logout.yml
+  when:
+    - enterprise_upgrade | default(false)
+    - not ansible_check_mode
+    - kv_command_check is defined
+    - kv_command_check.rc | default(0) == 0 
+    - kv_command_check.stdout | default('') != ""

--- a/roles/cca.splunk.enterprise-install/tasks/shcluster_upgrade_handler.yml
+++ b/roles/cca.splunk.enterprise-install/tasks/shcluster_upgrade_handler.yml
@@ -17,30 +17,5 @@
   include_tasks: shcluster/shcluster_member_by_member_upgrade.yml
   when: shc_upgrade_method | default('') == 'member_by_member'
 
-# First check if the KVStore upgrade status command is available (to avoid the "not a valid argument" error)
-- name: Check if standalone-kvupgrade-status command is available
-  ansible.builtin.shell: "timeout 30 {{ splunk_path }}/bin/splunk help show | grep standalone-kvupgrade-status"
-  register: kv_command_check
-  ignore_errors: true
-  changed_when: false
-  when:
-    - enterprise_upgrade | default(false)
-    - not ansible_check_mode
-  no_log: "{{ hide_password | default(false) }}"
-
-- name: Wait for KVStore upgrade to complete
-  ansible.builtin.shell: "timeout 30 {{ splunk_path }}/bin/splunk show standalone-kvupgrade-status"
-  register: kv_status
-  until: kv_status.stdout is search('Upgrade Status:\s+0')
-  retries: "{{ cca_splunk_kvstore_upgrade_retries | default(30) | int }}"
-  delay: "{{ cca_splunk_kvstore_upgrade_delay | default(60) | int }}"
-  changed_when: false
-  failed_when:
-    - kv_status.stdout is not search('Upgrade Status:\s+0')
-    - "'is not a valid argument' not in kv_status.stderr"
-  when:
-    - enterprise_upgrade | default(false)
-    - not ansible_check_mode
-    - kv_command_check is defined
-    - kv_command_check.rc | default(0) == 0
-    - kv_command_check.stdout | default('') != ""
+- name: Include task to check kvstore upgrade status
+  include_tasks: kvstore_upgrade_status.yml

--- a/templates/infrastructure_template/splunk/etc/auth/certs/cert_inspect.sh
+++ b/templates/infrastructure_template/splunk/etc/auth/certs/cert_inspect.sh
@@ -1,4 +1,4 @@
-#!/usr/local/env bash
+#!/usr/bin/env bash
 
 # cert_inspect.sh - PEM certificate utility for inspection and validation
 #
@@ -36,7 +36,7 @@ function validate_server_cert() {
 
   echo "🔍 Checking server certificate content..."
   local cert_count
-  cert_count=$(grep -c '-----BEGIN CERTIFICATE-----' "$server_cert")
+  cert_count=$(grep -c -- '-----BEGIN CERTIFICATE-----' "$server_cert")
 
   if (( cert_count > 1 )); then
     echo "⚠️  WARNING: Server certificate '$server_cert' contains multiple certificates ($cert_count)."


### PR DESCRIPTION
Rewrite of cgroups handler for seamless upgrade to v2 after Splunk Enterprise upgrade to 9.4. Run configure_linux_servers.yml post upgrade of Splunk to switch to cgroups2.

Improved kvstore upgrade logic to work with initial install and SHC Member upgrade process. 