### PR TITLE
CCA for Splunk 2025.1.1.1

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -31,6 +31,10 @@
 
     Release notes:
 
+    2025.1.1.1
+              Bug fixes:
+                * Corrected destination path for app deployment after migration to ansible ynchronize module.
+
     2025.1.1
               - Important:
                  * This version of CCA deprecates OS versions incompatible with Ansible 2.17+. To proceed

--- a/roles/cca.splunk.onboarding/tasks/deploy_apps.yml
+++ b/roles/cca.splunk.onboarding/tasks/deploy_apps.yml
@@ -7,14 +7,14 @@
 #
 # Author: Roger Lindquist (github.com/rlinq)
 #
-# Release: 2025.1.1
+# Release: 2025.1.1.1
 
 - name: Deploy the apps from the selected apps directory to the splunk servers
   ansible.posix.synchronize:
     src:  >-
         {{
           (item.source_path | default(selected_apps_source_path)) ~
-          ('/' ~ item.source_app if item.source_app is defined else '')
+          ('/' ~ item.source_app if item.source_app is defined else '') ~ '/'
         }}
     dest: "{{ splunk_path }}/etc/{{ item.dest_dir | default('apps') }}/{{ item.name }}/"
     copy_links: true
@@ -43,7 +43,7 @@
     src: >-
         {{
           (item.source_path | default(versioned_apps_source_path)) ~
-          ('/' ~ item.source_app if item.source_app is defined else '')
+          ('/' ~ item.source_app if item.source_app is defined else '') ~ '/'
         }}
     dest: "{{ splunk_path }}/etc/{{ item.dest_dir | default('apps') }}/{{ item.name }}/"
     copy_links: true


### PR DESCRIPTION
Corrected destination path for app deployment after migration to ansible ynchronize module.