### PR TITLE
CCA for Splunk v2025.3.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![alt text](/media/CCAforSplunk_orange.png)
 <br>
-<img align="right" src="https://badgen.net/badge/Latest%20Premium%20Version/2025.3.1.1/green?icon=github"><img align="right" src="https://badgen.net/badge/Latest%20Release/2025.3.1/green?icon=github"><img align="right" src="https://badgen.net/badge/License/MIT/blue">
+<img align="right" src="https://badgen.net/badge/Latest%20Premium%20Version/2025.3.1.2/green?icon=github"><img align="right" src="https://badgen.net/badge/Latest%20Release/2025.3.1.2/green?icon=github"><img align="right" src="https://badgen.net/badge/License/MIT/blue">
 <br>
 ### A full lifecycle management interface for Splunk
 

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -31,6 +31,32 @@
 
     Release notes:
 
+    2025.3.1.2
+              - Enhanced deployment server reload state file cleanup during Splunk restarts and server reboots.
+                Ensures both restart and reload state files are properly cleaned up on deployment servers.
+              - Updated deprecated ansible environment variable ANSIBLE_STDOUT_CALLBACK=yaml. Use these variables
+                instead, set them in your ~/.profile_local file on your manager server.
+                    export ANSIBLE_STDOUT_CALLBACK=ansible.builtin.default
+                    export ANSIBLE_CALLBACK_RESULT_FORMAT=yaml
+                    export ANSIBLE_CALLBACK_FORMAT_PRETTY=true
+
+              Bug fixes:
+                * Corrected an issue with onboarding groups that use the dest_dir option. Incorrect variable used
+                  in directory references.
+                * Include jq in the list of cca_baseline_software, defined in group_vars/all/linux. Copy settings from
+                  the infrastructure group_vars/all/linux template file.
+                * Improved robustness of rsync status classification filters to handle empty lists and invalid input.
+                * Fixed certificate validation error handling with proper default values for undefined variables.
+                * Corrected onboarding task variable references and improved ansible-lint compliance across multiple files.
+
+
+    2025.3.1.1
+              - Added configurable temporary directory option for rsync operations during app staging.
+                Set cca_local_tmp_dir to override default /tmp/cca_tmp directory location, update
+                your local settings from the updated file in templates directory
+                onboarding_templates/environment/ENVIRONMENT_NAME/group_vars/all/onboarding
+
+
     2025.3.1
               - Bumped Splunk Enterprise version to 9.4.4, Splunk 9.4.x track is recommended for production usage.
               - Improved index cluster preflight status when running deploy_manager_apps.yml playbook, fail fast

--- a/cca_ctrl
+++ b/cca_ctrl
@@ -78,7 +78,7 @@ else
 fi
 
 WhiptailHight=30
-BackTitle="   $(hostname -s) - CCA for Splunk $(date +'%Y') v2025.3.1"
+BackTitle="   $(hostname -s) - CCA for Splunk $(date +'%Y') v2025.3.1.2"
 CookieFile="${ScriptPath}/.cookie"
 LicenseFile=~/clones/cca_for_splunk/LICENSE
 InfoFile=~/clones/cca_for_splunk/RELEASE_NOTES.txt

--- a/playbooks/automation_readiness_cca_manager.yml
+++ b/playbooks/automation_readiness_cca_manager.yml
@@ -11,7 +11,7 @@
   pre_tasks:
     - name: Set CCA release version of readiness playbook
       ansible.builtin.set_fact:
-        cca_release: "2025.3.1"
+        cca_release: "2025.3.1.2"
 
     - name: START - Set target readiness score for CCA manager
       ansible.builtin.set_fact:
@@ -240,7 +240,7 @@
       ignore_errors: true
       register: assert_result
 
-    - name: Increase score for successful recommended task - ANSIBLE_STRATEGY_PLUGINS
+    - name: Increase score for successful recommended task - ANSIBLE_STRATEGY
       ansible.builtin.set_fact:
         mgr_readiness_score: "{{ mgr_readiness_score | int + 99 }}"
       when:

--- a/playbooks/setup_cca_manager.yml
+++ b/playbooks/setup_cca_manager.yml
@@ -17,7 +17,7 @@
       when:
         - not post_docker_setup is defined
 
-    - name: Post confgiuration of CCA Manager if running in docker instance
+    - name: Post configuration of CCA Manager if running in docker instance
       ansible.builtin.include_role:
         name: ./roles/cca.setup.cca-manager
         tasks_from:

--- a/roles/cca.core.control/tasks/cleanup_temp_files.yml
+++ b/roles/cca.core.control/tasks/cleanup_temp_files.yml
@@ -7,12 +7,12 @@
 #
 # Author: Roger Lindquist (github.com/rlinq)
 #
-# Release: 2025.3.1
+# Release: 2025.3.1.1
 
 
 - name: Clean up temporary files
   ansible.builtin.file:
-    path: "{{ (cca_local_tmp_dir | default('/tmp')) }}/{{ cca_runid }}"
+    path: "{{ (cca_local_tmp_dir | default('/tmp/cca_tmp')) }}/{{ cca_runid }}"
     state: absent
   changed_when: false
 
@@ -22,7 +22,7 @@
 
 - name: Find and delete old temporary files owned by current user
   ansible.builtin.shell: |
-    find {{ cca_local_tmp_dir | default('/tmp') | quote }} \
+    find {{ cca_local_tmp_dir | default('/tmp/cca_tmp') | quote }} \
          -xdev -type f -user {{ current_user | quote }} \
          -mmin +{{ cca_cleanup_tmp_files_age | default('240') }} \
          -delete 2> /dev/null || true

--- a/roles/cca.core.linux/tasks/server_reboot_handler.yml
+++ b/roles/cca.core.linux/tasks/server_reboot_handler.yml
@@ -7,7 +7,7 @@
 #
 # Author: Roger Lindquist (github.com/rlinq)
 #
-# Release: 2025.1.1
+# Release: 2025.3.1.2
 
 
 - name: Gather facts about configured services
@@ -64,6 +64,15 @@
         - server_reboot_status.rebooted
       check_mode: false
 
+    - name: Delete deployment server reload statefile based on reboot status
+      ansible.builtin.file:
+        path: "{{ deployment_server_reload_pending | default('/opt/splunk/var/run/splunk_deployment_server_reload.pending') }}"
+        state: 'absent'
+      when:
+        - server_reboot_status.rebooted
+        - inventory_hostname in ( groups.deployment_servers | default([]) )
+      check_mode: false
+
     - name: Set fact that cgroups has been configured
       ansible.builtin.set_fact:
         cgroups_configured: true
@@ -91,5 +100,14 @@
   loop:
     - "{{ splunk_service_restart_pending | default('/tmp/splunk_service_restart.pending') }}"
     - "{{ splunk_service_status | default('/var/tmp/splunkd_service_started') }}"
+  check_mode: false
+  changed_when: false
+
+- name: Cleanup deployment server reload state file
+  ansible.builtin.file:
+    path: "{{ deployment_server_reload_pending | default('/opt/splunk/var/run/splunk_deployment_server_reload.pending') }}"
+    state: absent
+  when:
+    - inventory_hostname in ( groups.deployment_servers | default([]) )
   check_mode: false
   changed_when: false

--- a/roles/cca.core.splunk/filter_plugins/classify_apps_rsync_status.py
+++ b/roles/cca.core.splunk/filter_plugins/classify_apps_rsync_status.py
@@ -9,6 +9,14 @@ def classify_apps(rsync_output):
     if not isinstance(rsync_output, list):
         raise AnsibleFilterError("The input should be a list of strings representing rsync output lines.")
 
+    # Handle empty list case
+    if not rsync_output:
+        return json.dumps({
+            'Removed': [],
+            'Added': [],
+            'Modified': []
+        }, indent=2)
+
     apps = {
         'Removed': set(),
         'Added': set(),
@@ -22,6 +30,10 @@ def classify_apps(rsync_output):
     existing_apps = set()
 
     for line in rsync_output:
+        # Skip empty lines or None values
+        if not line or not isinstance(line, str):
+            continue
+
         add_match = add_pattern.search(line)
         delete_match = delete_pattern.search(line)
         modify_match = modify_pattern.search(line)

--- a/roles/cca.core.splunk/tasks/deployment_server/get_serverclass_map_of_deployment_apps.yml
+++ b/roles/cca.core.splunk/tasks/deployment_server/get_serverclass_map_of_deployment_apps.yml
@@ -7,7 +7,7 @@
 #
 # Author: Roger Lindquist (github.com/rlinq)
 #
-# Release: 2025.2.1
+# Release: 2025.3.1.1
 
 - name: Classify apps based on rsync output
   ansible.builtin.set_fact:
@@ -20,7 +20,7 @@
   ansible.builtin.set_fact:
     serverclass_data:
       "{{ lookup('file',
-      (cca_local_tmp_dir | default('/tmp')) ~ '/' ~ cca_runid ~ '/'  ~ environment_name ~ '/' ~ 'localhost' ~ '/serverclass_data_local.json') }}"
+      (cca_local_tmp_dir | default('/tmp/cca_tmp')) ~ '/' ~ cca_runid ~ '/'  ~ environment_name ~ '/' ~ 'localhost' ~ '/serverclass_data_local.json') }}"
   no_log: "{{ hide_password }}"
 
 - name: Perform lookup for classified apps

--- a/roles/cca.core.splunk/tasks/deployment_server/get_serverclass_state.yml
+++ b/roles/cca.core.splunk/tasks/deployment_server/get_serverclass_state.yml
@@ -7,7 +7,7 @@
 #
 # Author: Roger Lindquist (github.com/rlinq)
 #
-# Release: 2025.3.1
+# Release: 2025.3.1.2
 
 
 - name: Set fact for ds inventory name
@@ -35,7 +35,7 @@
   connection: local
   become: false
   ansible.builtin.file:
-    path: "{{ (cca_local_tmp_dir | default('/tmp')) }}/{{ cca_runid }}/{{ environment_name }}/{{ hostvars['localhost']['ds_inventory_hostname'] }}"
+    path: "{{ (cca_local_tmp_dir | default('/tmp/cca_tmp')) }}/{{ cca_runid }}/{{ environment_name }}/{{ hostvars['localhost']['ds_inventory_hostname'] }}"
     state: directory
     mode: '0755'
   changed_when: false
@@ -54,7 +54,7 @@
   become: false
   ansible.builtin.copy:
     src: "{{ role_path }}/files/bin/compare_serverclass_data.py"
-    dest: "{{ (cca_local_tmp_dir | default('/tmp')) }}/{{ cca_runid }}/{{ environment_name }}/compare_serverclass_data.py"
+    dest: "{{ (cca_local_tmp_dir | default('/tmp/cca_tmp')) }}/{{ cca_runid }}/{{ environment_name }}/compare_serverclass_data.py"
     mode: '0755'
   delegate_to: localhost
   changed_when: false
@@ -64,7 +64,7 @@
   connection: local
   become: false
   ansible.builtin.file:
-    path: "{{ (cca_local_tmp_dir | default('/tmp')) }}/{{ cca_runid }}/{{ environment_name }}/localhost"
+    path: "{{ (cca_local_tmp_dir | default('/tmp/cca_tmp')) }}/{{ cca_runid }}/{{ environment_name }}/localhost"
     state: 'directory'
     mode: '0755'
     recurse: true
@@ -89,9 +89,9 @@
   ansible.builtin.command: >
     {{ ansible_python_interpreter }} {{ role_path }}/files/bin/sc_parser.py
     {{ local_directory }}
-    {{ [cca_local_tmp_dir | default('/tmp'), cca_runid, environment_name, 'localhost', 'serverclass_data_local.json'] | path_join }}
-    {{ [cca_local_tmp_dir | default('/tmp'), cca_runid, environment_name, 'localhost', 'duplicates_data_local.json'] | path_join }}
-    {{ [cca_local_tmp_dir | default('/tmp'), cca_runid, environment_name, 'localhost'] | path_join }}
+    {{ [cca_local_tmp_dir | default('/tmp/cca_tmp'), cca_runid, environment_name, 'localhost', 'serverclass_data_local.json'] | path_join }}
+    {{ [cca_local_tmp_dir | default('/tmp/cca_tmp'), cca_runid, environment_name, 'localhost', 'duplicates_data_local.json'] | path_join }}
+    {{ [cca_local_tmp_dir | default('/tmp/cca_tmp'), cca_runid, environment_name, 'localhost'] | path_join }}
   delegate_to: localhost
   register: local_result
   changed_when: false
@@ -102,7 +102,7 @@
   become: false
   delegate_to: localhost
   ansible.builtin.slurp:
-    src: "{{ (cca_local_tmp_dir | default('/tmp')) }}/{{ cca_runid }}/{{ environment_name }}/localhost/duplicates_data_local.json"
+    src: "{{ (cca_local_tmp_dir | default('/tmp/cca_tmp')) }}/{{ cca_runid }}/{{ environment_name }}/localhost/duplicates_data_local.json"
   register: duplicates_data
 
 - name: Check if duplicates data is present
@@ -118,8 +118,12 @@
 
 - name: Set remote and local base path
   ansible.builtin.set_fact:
-    remote_base_path: "{{ [cca_remote_tmp_dir | default('/tmp'), cca_runid, environment_name, hostvars['localhost']['ds_inventory_hostname']] | path_join }}"
-    local_base_path: "{{ [cca_local_tmp_dir | default('/tmp'), cca_runid, environment_name, hostvars['localhost']['ds_inventory_hostname']] | path_join }}"
+    remote_base_path: >-
+      {{ [cca_remote_tmp_dir | default('/tmp'),
+         cca_runid, environment_name, hostvars['localhost']['ds_inventory_hostname']] | path_join }}
+    local_base_path: >-
+      {{ [cca_local_tmp_dir | default('/tmp/cca_tmp'),
+         cca_runid, environment_name, hostvars['localhost']['ds_inventory_hostname']] | path_join }}
 
 - name: Set intermediate variable
   ansible.builtin.set_fact:
@@ -127,7 +131,7 @@
     remote_duplicates_json: "{{ [remote_base_path, 'duplicates_data_remote.json'] | path_join }}"
     local_serverclass_json: "{{ [local_base_path, 'serverclass_data_remote.json'] | path_join }}"
     local_duplicates_json: "{{ [local_base_path, 'duplicates_data_remote.json'] | path_join }}"
-    compare_script_path: "{{ [cca_local_tmp_dir | default('/tmp'), cca_runid, environment_name, 'compare_serverclass_data.py'] | path_join }}"
+    compare_script_path: "{{ [cca_local_tmp_dir | default('/tmp/cca_tmp'), cca_runid, environment_name, 'compare_serverclass_data.py'] | path_join }}"
 
 - name: Run sc_parser.py on remote host
   ansible.builtin.command: >
@@ -162,7 +166,7 @@
   become: false
   ansible.builtin.command: >
     {{ ansible_python_interpreter }} {{ compare_script_path }}
-    {{ [cca_local_tmp_dir | default('/tmp'), cca_runid, environment_name, 'localhost', 'serverclass_data_local.json'] | path_join }}
+    {{ [cca_local_tmp_dir | default('/tmp/cca_tmp'), cca_runid, environment_name, 'localhost', 'serverclass_data_local.json'] | path_join }}
     {{ local_serverclass_json }}
   delegate_to: localhost
   changed_when: false

--- a/roles/cca.core.splunk/tasks/restart_splunkd.yml
+++ b/roles/cca.core.splunk/tasks/restart_splunkd.yml
@@ -7,7 +7,7 @@
 #
 # Author: Roger Lindquist (github.com/rlinq)
 #
-# Release: 2025.2.1
+# Release: 2025.3.1.2
 
 - name: Perform a splunkd restart in a block
   block:
@@ -35,6 +35,16 @@
       tags:
         - skip_ansible_lint
 
+    - name: Perform a cleanup of deployment server reload state file
+      ansible.builtin.file:
+        path: "{{ deployment_server_reload_pending }}"
+        state: absent
+      when:
+        - splunk_restart_result.changed | default(false)
+        - inventory_hostname in ( groups.deployment_servers | default([]) )
+      tags:
+        - skip_ansible_lint
+
   rescue:
     - name: Check if restart failed due to web interface unavailability
       ansible.builtin.fail:
@@ -59,5 +69,15 @@
         state: absent
       when:
         - splunk_restart_result.changed | default(false)
+      tags:
+        - skip_ansible_lint
+
+    - name: Perform a cleanup of deployment server reload state file after recovery
+      ansible.builtin.file:
+        path: "{{ deployment_server_reload_pending }}"
+        state: absent
+      when:
+        - splunk_restart_result.changed | default(false)
+        - inventory_hostname in ( groups.deployment_servers | default([]) )
       tags:
         - skip_ansible_lint

--- a/roles/cca.setup.cca-manager/tasks/configure_cca_manager_user.yml
+++ b/roles/cca.setup.cca-manager/tasks/configure_cca_manager_user.yml
@@ -132,8 +132,9 @@
     - { regex: 'ANSIBLE_PRIVATE_KEY_FILE', value: 'export ANSIBLE_PRIVATE_KEY_FILE={{ cca_ansible_private_key_file }}' }
     - { regex: 'ANSIBLE_HOST_KEY_CHECKING', value: 'export ANSIBLE_HOST_KEY_CHECKING=false' }
     - { regex: 'ANSIBLE_CALLBACKS_ENABLED', value: 'export ANSIBLE_CALLBACKS_ENABLED=ansible.posix.profile_tasks' }
-    - { regex: 'ANSIBLE_CALLBACK_ENABLED', value: 'export ANSIBLE_CALLBACK_ENABLED=profile_tasks' }
-    - { regex: 'ANSIBLE_STDOUT_CALLBACK', value: 'export ANSIBLE_STDOUT_CALLBACK=yaml' }
+    - { regex: 'ANSIBLE_STDOUT_CALLBACK', value: 'export ANSIBLE_STDOUT_CALLBACK=ansible.builtin.default' }
+    - { regex: 'ANSIBLE_CALLBACK_RESULT_FORMAT', value: 'export ANSIBLE_CALLBACK_RESULT_FORMAT=yaml' }
+    - { regex: 'ANSIBLE_CALLBACK_FORMAT_PRETTY', value: 'export ANSIBLE_CALLBACK_FORMAT_PRETTY=true' }
     - { regex: "python='/usr/bin/python'", value: "alias python='{{ result_python_path.stdout }}'" }
     - { regex: 'source ~/tools/python-venv/ansible', value: 'source ~/tools/python-venv/ansible{{ cca_ansible_minor_version }}/bin/activate' }
 

--- a/roles/cca.setup.cca-manager/tasks/post_configure_cca_manager_user.yml
+++ b/roles/cca.setup.cca-manager/tasks/post_configure_cca_manager_user.yml
@@ -70,8 +70,9 @@
     - { regex: 'ANSIBLE_PRIVATE_KEY_FILE', value: 'export ANSIBLE_PRIVATE_KEY_FILE={{ cca_ansible_private_key_file }}' }
     - { regex: 'ANSIBLE_HOST_KEY_CHECKING', value: 'export ANSIBLE_HOST_KEY_CHECKING=false' }
     - { regex: 'ANSIBLE_CALLBACKS_ENABLED', value: 'export ANSIBLE_CALLBACKS_ENABLED=ansible.posix.profile_tasks' }
-    - { regex: 'ANSIBLE_CALLBACK_ENABLED', value: 'export ANSIBLE_CALLBACK_ENABLED=profile_tasks' }
-    - { regex: 'ANSIBLE_STDOUT_CALLBACK', value: 'export ANSIBLE_STDOUT_CALLBACK=yaml' }
+    - { regex: 'ANSIBLE_STDOUT_CALLBACK', value: 'export ANSIBLE_STDOUT_CALLBACK=ansible.builtin.default' }
+    - { regex: 'ANSIBLE_CALLBACK_RESULT_FORMAT', value: 'export ANSIBLE_CALLBACK_RESULT_FORMAT=yaml' }
+    - { regex: 'ANSIBLE_CALLBACK_FORMAT_PRETTY', value: 'export ANSIBLE_CALLBACK_FORMAT_PRETTY=true' }
     - { regex: "python='/usr/bin/python'", value: "alias python='{{ result_python_path.stdout }}'" }
     - { regex: 'source ~/tools/python-venv/ansible', value: 'source ~/tools/python-venv/ansible{{ cca_ansible_minor_version }}/bin/activate' }
     - { regex: 'export CCA_INFRASTRUCTURE_REPO_DIR', value: 'export CCA_INFRASTRUCTURE_REPO_DIR=~/main/cca_splunk_infrastructure' }

--- a/roles/cca.splunk.onboarding/tasks/deployment_server/deploy_serverclass_apps.yml
+++ b/roles/cca.splunk.onboarding/tasks/deployment_server/deploy_serverclass_apps.yml
@@ -7,13 +7,12 @@
 #
 # Author: Roger Lindquist (github.com/rlinq)
 #
-# Release: 2024.2.1
-
+# Release: 2025.3.1.2
 
 - name: Deploy apps from the staging directory to the deployment server apps directory
   become: false
   ansible.posix.synchronize:
-    src: '{{ (cca_local_tmp_dir | default("/tmp")) }}/{{ cca_runid }}/{{ environment_name }}/localhost/'
+    src: '{{ (cca_local_tmp_dir | default("/tmp/cca_tmp")) }}/{{ cca_runid }}/{{ environment_name }}/localhost/'
     dest: '{{ splunk_path }}/etc/apps/'
     copy_links: true
     recursive: true

--- a/roles/cca.splunk.onboarding/tasks/main.yml
+++ b/roles/cca.splunk.onboarding/tasks/main.yml
@@ -7,7 +7,7 @@
 #
 # Author: Roger Lindquist (github.com/rlinq)
 #
-# Release: 2025.3.1
+# Release: 2025.3.1.1
 
 # tasks file for cca.splunk.onboarding
 
@@ -18,6 +18,16 @@
 - name: Set variable for versioned_apps source path
   ansible.builtin.set_fact:
     versioned_apps_source_path: '{{ versioned_apps_absolute_sourcedir | default(absolute_file_store_path + "/etc/" + versioned_apps_sourcedir) }}'
+
+- name: Ensure local tmp directory exists
+  become: false
+  delegate_to: localhost
+  connection: local
+  ansible.builtin.file:
+    path: "{{ cca_local_tmp_dir | default('/tmp/cca_tmp') }}"
+    state: directory
+    mode: '0700'
+  check_mode: false
 
 - name: Include task for shcluster app staging
   ansible.builtin.include_tasks: stage_shcluster_apps.yml
@@ -116,7 +126,7 @@
   connection: local
   become: false
   ansible.builtin.file:
-    path: "{{ (cca_local_tmp_dir | default('/tmp')) }}/{{ cca_runid }}/{{ environment_name }}"
+    path: "{{ (cca_local_tmp_dir | default('/tmp/cca_tmp')) }}/{{ cca_runid }}/{{ environment_name }}"
     state: absent
   changed_when: false
   failed_when: false

--- a/roles/cca.splunk.onboarding/tasks/stage_deployment_apps.yml
+++ b/roles/cca.splunk.onboarding/tasks/stage_deployment_apps.yml
@@ -7,19 +7,30 @@
 #
 # Author: Roger Lindquist (github.com/rlinq)
 #
-# Release: 2025.2.1
+# Release: 2025.3.1.2
 
 - name: Set staging directory
   ansible.builtin.set_fact:
     deployment_server_apps_staging_dir: >-
      {{ (cca_local_tmp_dir
-        | default("/tmp")) }}/{{ cca_runid }}/{{ environment_name }}/{{ inventory_hostname }}/{{ environment_name }}
+        | default("/tmp/cca_tmp")) }}/{{ cca_runid }}/{{ environment_name }}/{{ inventory_hostname }}/{{ environment_name }}
     selected_apps_source_dir: >-
+      {{
+        selected_apps_absolute_sourcedir
+        | default(absolute_file_store_path + '/etc/' + selected_apps_sourcedir)
+      }}
+    selected_deployment_apps_source_dir: >-
       {{
         selected_deployment_apps_absolute_sourcedir
         | default(absolute_file_store_path + '/etc/' + selected_deployment_apps_sourcedir)
       }}
-- name: Cleanup manager before staging apps§
+    deployment_apps_absolute_source_dir: >-
+      {{
+        deployment_apps_absolute_sourcedir
+        | default(absolute_file_store_path + '/etc/' + deployment_apps_sourcedir + '/' + environment_name)
+      }}
+
+- name: Cleanup manager before staging apps
   become: false
   connection: local
   ansible.builtin.file:
@@ -44,7 +55,7 @@
   become: false
   connection: local
   ansible.builtin.stat:
-    path: "{{ deployment_apps_absolute_sourcedir | default(absolute_file_store_path + '/etc/' + deployment_apps_sourcedir) }}"
+    path: "{{ selected_deployment_apps_source_dir }}"
   register: stat_environment_specific_path
   delegate_to: localhost
   check_mode: false
@@ -54,15 +65,15 @@
     that:
       - stat_environment_specific_path.stat.exists
     fail_msg: >-
-      The directory {{ deployment_apps_absolute_sourcedir | default(absolute_file_store_path + '/etc/' + deployment_apps_sourcedir) }} is missing
+      The directory {{ selected_deployment_apps_source_dir }} is missing
       correct and rerun the playbook.
 
 - name: Stage manager with deployment apps from environment directory
   become: false
   connection: local
-  ansible.builtin.command: >
-    rsync --delay-updates -F --compress --archive
-    "{{ deployment_apps_absolute_sourcedir | default(absolute_file_store_path + '/etc/' + deployment_apps_sourcedir) }}/"
+  ansible.builtin.command: >-
+    rsync --temp-dir="{{ cca_local_tmp_dir | default('/tmp/cca_tmp') }}" --delay-updates -F --compress --archive
+    "{{ deployment_apps_absolute_source_dir }}/"
     "{{ deployment_server_apps_staging_dir }}/deployment_server/"
   delegate_to: localhost
   changed_when: false
@@ -74,8 +85,8 @@
   become: false
   connection: local
   ansible.builtin.command: >
-    rsync --delay-updates -F --compress --archive
-    "{{ selected_apps_source_dir }}/{{ item.source_app }}/"
+    rsync --temp-dir="{{ cca_local_tmp_dir | default('/tmp/cca_tmp') }}" --delay-updates -F --compress --archive
+    "{{ selected_deployment_apps_source_dir }}/{{ item.source_app }}/"
     "{{ deployment_server_apps_staging_dir }}/deployment_server/{{ item.name }}/"
   delegate_to: localhost
   when:
@@ -92,7 +103,7 @@
   become: false
   connection: local
   ansible.builtin.command: >
-    rsync --delay-updates -F --compress --archive
+    rsync --temp-dir="{{ cca_local_tmp_dir | default('/tmp/cca_tmp') }}" --delay-updates -F --compress --archive
     "{{ versioned_apps_source_path if item.source_path is not defined else item.source_path }}/{{ item.source_app }}/"
     "{{ deployment_server_apps_staging_dir }}/deployment_server/{{ item.name }}/"
   delegate_to: localhost
@@ -111,10 +122,11 @@
 - name: Stage manager with selected apps
   become: false
   connection: local
-  ansible.builtin.command: >
-    rsync --delay-updates -F --compress --archive
-    "{{ (item.source_path | default(selected_apps_source_path)) ~ ('/' ~ item.source_app if item.source_app is defined else '') }}/"
-    "{{ deployment_server_apps_staging_dir }}/deployment_server/{{ item.name }}/"
+  ansible.builtin.command: >-
+    rsync --temp-dir="{{ cca_local_tmp_dir | default('/tmp/cca_tmp') }}" --delay-updates -F --compress --archive
+    {{ (item.source_path | default(selected_apps_source_dir) ))
+    ~ ('/' ~ item.source_app if item.source_app is defined else '') }}/
+    {{ deployment_server_apps_staging_dir }}/deployment_server/{{ item.name }}/
   delegate_to: localhost
   when:
     - item.dest_dir is defined

--- a/roles/cca.splunk.onboarding/tasks/stage_manager_apps.yml
+++ b/roles/cca.splunk.onboarding/tasks/stage_manager_apps.yml
@@ -7,11 +7,30 @@
 #
 # Author: Roger Lindquist (github.com/rlinq)
 #
-# Release: 2025.2.1
+# Release: 2025.3.1.2
 
 - name: Set staging directory
   ansible.builtin.set_fact:
-    manager_apps_staging_dir: '{{ (cca_local_tmp_dir | default("/tmp")) }}/{{ cca_runid }}/{{ environment_name }}/{{ inventory_hostname }}/{{ cluster_label }}'
+    manager_apps_staging_dir: >-
+      {{
+        (cca_local_tmp_dir | default("/tmp/cca_tmp")) + '/' + cca_runid + '/' +
+        environment_name + '/' + inventory_hostname + '/' + cluster_label
+      }}
+    selected_apps_source_dir: >-
+      {{
+        selected_apps_absolute_sourcedir
+        | default(absolute_file_store_path + '/etc/' + selected_apps_sourcedir)
+      }}
+    selected_manager_apps_source_dir: >-
+      {{
+        selected_manager_apps_absolute_sourcedir
+        | default(absolute_file_store_path + '/etc/' + selected_manager_apps_sourcedir)
+      }}
+    manager_apps_absolute_source_dir: >-
+      {{
+        manager_apps_absolute_sourcedir
+        | default(absolute_file_store_path + '/etc/' + manager_apps_sourcedir)
+      }}
 
 - name: Cleanup manager before staging apps
   become: false
@@ -40,8 +59,8 @@
   become: false
   connection: local
   ansible.builtin.command: >
-    rsync --delay-updates -F --compress --archive
-    "{{ manager_apps_absolute_sourcedir | default(absolute_file_store_path + '/etc/' + manager_apps_sourcedir) }}/"
+    rsync --temp-dir="{{ cca_local_tmp_dir | default('/tmp/cca_tmp') }}" --delay-updates -F --compress --archive
+    "{{ manager_apps_absolute_source_dir }}/"
     "{{ manager_apps_staging_dir }}/"
   delegate_to: localhost
   when:
@@ -55,7 +74,7 @@
   become: false
   connection: local
   ansible.builtin.command: >
-    rsync --delay-updates -F --compress --archive
+    rsync --temp-dir="{{ cca_local_tmp_dir | default('/tmp/cca_tmp') }}" --delay-updates -F --compress --archive
     "{{ selected_manager_apps_absolute_sourcedir | default(absolute_file_store_path + '/etc/' + selected_manager_apps_sourcedir) }}/{{ item.source_app }}/"
     "{{ manager_apps_staging_dir }}/{{ item.name }}/"
   delegate_to: localhost
@@ -73,7 +92,7 @@
   become: false
   connection: local
   ansible.builtin.command: >
-    rsync --delay-updates -F --compress --archive
+    rsync --temp-dir="{{ cca_local_tmp_dir | default('/tmp/cca_tmp') }}" --delay-updates -F --compress --archive
     "{{ (item.source_path | default(versioned_apps_source_path)) ~ ('/' ~ item.source_app if item.source_app is defined else '') }}/"
     "{{ manager_apps_staging_dir }}/{{ item.name }}/"
   delegate_to: localhost
@@ -94,12 +113,11 @@
   become: false
   connection: local
   ansible.builtin.command: >
-    rsync --delay-updates -F --compress --archive
-    "{{ (item.source_path | default(selected_apps_source_path)) ~ ('/' ~ item.source_app if item.source_app is defined else '') }}/"
+    rsync --temp-dir="{{ cca_local_tmp_dir | default('/tmp/cca_tmp') }}" --delay-updates -F --compress --archive
+    "{{ (item.source_path | default(selected_apps_source_dir)) ~ ('/' ~ item.source_app if item.source_app is defined else '') }}/"
     "{{ manager_apps_staging_dir }}/{{ item.name }}/"
   delegate_to: localhost
   when:
-    - selected_apps_source_path is defined
     - item.dest_dir is defined
     - item.dest_dir == 'manager-apps' or
       item.dest_dir == 'master-apps'

--- a/roles/cca.splunk.onboarding/tasks/stage_shcluster_apps.yml
+++ b/roles/cca.splunk.onboarding/tasks/stage_shcluster_apps.yml
@@ -7,11 +7,27 @@
 #
 # Author: Roger Lindquist (github.com/rlinq)
 #
-# Release: 2025.2.1
+# Release: 2025.3.1.2
 
 - name: Set staging directory
   ansible.builtin.set_fact:
-    shcluster_staging_dir: '{{ (cca_local_tmp_dir | default("/tmp")) }}/{{ cca_runid }}/{{ environment_name }}/{{ inventory_hostname }}/{{ shcluster_label }}'
+    shcluster_staging_dir: >-
+      '{{ (cca_local_tmp_dir | default("/tmp/cca_tmp")) }}/{{ cca_runid }}/{{ environment_name }}/{{ inventory_hostname }}/{{ shcluster_label }}'
+    selected_apps_source_dir: >-
+      {{
+        selected_apps_absolute_sourcedir
+        | default(absolute_file_store_path + '/etc/' + selected_apps_sourcedir)
+      }}
+    selected_shcluster_apps_source_dir: >-
+      {{
+        selected_shcluster_apps_absolute_sourcedir
+        | default(absolute_file_store_path + '/etc/' + selected_shcluster_apps_sourcedir)
+      }}
+    shcluster_apps_absolute_source_dir: >-
+      {{
+        shcluster_apps_absolute_sourcedir
+        | default(absolute_file_store_path + '/etc/' + shcluster_apps_sourcedir)
+      }}
 
 - name: Cleanup manager before staging apps
   become: false
@@ -34,13 +50,14 @@
     state: directory
     mode: '0700'
   changed_when: false
+  check_mode: false
 
 - name: Stage manager with shcluster apps from shcluster directory
   become: false
   connection: local
   ansible.builtin.command: >
-    rsync --delay-updates -F --compress --archive
-    "{{ shcluster_apps_absolute_sourcedir | default(absolute_file_store_path + '/etc/' + shcluster_apps_sourcedir) }}/"
+    rsync --temp-dir="{{ cca_local_tmp_dir | default('/tmp/cca_tmp') }}" --delay-updates -F --compress --archive
+    "{{ shcluster_apps_absolute_source_dir }}/"
     "{{ shcluster_staging_dir }}/apps/"
   delegate_to: localhost
   when:
@@ -53,9 +70,9 @@
 - name: Stage manager with shcluster selected apps
   become: false
   connection: local
-  ansible.builtin.command: >
-    rsync --delay-updates -F --compress --archive
-    "{{ selected_shcluster_apps_absolute_sourcedir | default(absolute_file_store_path + '/etc/' + selected_shcluster_apps_sourcedir) }}/{{ item.source_app }}/"
+  ansible.builtin.command: >-
+    rsync --temp-dir="{{ cca_local_tmp_dir | default('/tmp/cca_tmp') }}" --delay-updates -F --compress --archive
+    "{{ selected_apps_source_dir | default(absolute_file_store_path + '/etc/' + selected_shcluster_apps_sourcedir) }}/{{ item.source_app }}/"
     "{{ shcluster_staging_dir }}/apps/{{ item.name }}/"
   delegate_to: localhost
   when:
@@ -71,8 +88,8 @@
 - name: Stage manager with versioned apps destined for search head cluster
   become: false
   connection: local
-  ansible.builtin.command: >
-    rsync --delay-updates -F --compress --archive
+  ansible.builtin.command: >-
+    rsync --temp-dir="{{ cca_local_tmp_dir | default('/tmp/cca_tmp') }}" --delay-updates -F --compress --archive
     "{{ (item.source_path | default(versioned_apps_source_path)) ~ ('/' ~ item.source_app if item.source_app is defined else '') }}/"
     "{{ shcluster_staging_dir }}/apps/{{ item.name }}/"
   delegate_to: localhost
@@ -91,9 +108,9 @@
 - name: Stage manager with selected apps destined for search head cluster
   become: false
   connection: local
-  ansible.builtin.command: >
-    rsync --delay-updates -F --compress --archive
-    "{{ (item.source_path | default(selected_apps_source_path)) ~ ('/' ~ item.source_app if item.source_app is defined else '') }}/"
+  ansible.builtin.command: >-
+    rsync --temp-dir="{{ cca_local_tmp_dir | default('/tmp/cca_tmp') }}" --delay-updates -F --compress --archive
+    "{{ (item.source_path | default(selected_apps_source_dir)) ~ ('/' ~ item.source_app if item.source_app is defined else '') }}/"
     "{{ shcluster_staging_dir }}/apps/{{ item.name }}/"
   delegate_to: localhost
   when:

--- a/roles/cca.splunk.ssl-certificates/tasks/validate_target_certificates.yml
+++ b/roles/cca.splunk.ssl-certificates/tasks/validate_target_certificates.yml
@@ -10,7 +10,7 @@
 #   (intermediate -> root) required to validate the server cert.
 #
 # Author: Roger Lindquist (github.com/rlinq)
-# Release: 2025.3.1
+# Release: 2025.3.1.2
 
 - name: Run certificate validation in a block
   when:
@@ -135,7 +135,7 @@
             openssl verify -x509_strict -CAfile {{ ca_chain_path }} {{ cca_splunk_extension_certs_path }}/{{ cert_staging_file_name }}
       when:
         - cca_splunk_cert_enrollment_method != 'selfsigned'
-        - openssl_verify_result is defined
+        - openssl_verify_result.rc is defined
         - openssl_verify_result.rc is defined
 
     - name: "Get certificate information and validate expiration"
@@ -150,7 +150,7 @@
       no_log: "{{ hide_password }}"
       when:
         - cca_splunk_cert_enrollment_method != 'selfsigned'
-        - openssl_verify_result is defined
+        - openssl_verify_result.rc is defined
         - openssl_verify_result.rc == 0
 
     - name: "Assert certificate has sufficient validity period"
@@ -165,15 +165,20 @@
           Minimum required validity period: {{ cca_splunk_cert_min_validity_days | default(30) }} days.
           Subject: {{ cert_info_result.subject.commonName | default('N/A') }},
           Issuer: {{ cert_info_result.issuer.commonName | default('N/A') }},
-          Valid from: {{ cert_info_result.not_before }},
-          Valid until: {{ cert_info_result.not_after }},
+          Valid from: {{ cert_info_result.not_before | default('N/A') }},
+          Valid until: {{ cert_info_result.not_after | default('N/A') }},
           Days until expiry:
-          {{ ((cert_info_result.not_after | to_datetime('%Y%m%d%H%M%S%z')) - (ansible_date_time.iso8601 | to_datetime('%Y-%m-%dT%H:%M:%S%z'))).days }}.
+          {{
+            ((cert_info_result.not_after | default('') | to_datetime('%Y%m%d%H%M%S%z')) -
+             (ansible_date_time.iso8601 | to_datetime('%Y-%m-%dT%H:%M:%S%z'))).days |
+            default('N/A')
+          }}.
           Please ensure the certificate is valid for at least {{ cca_splunk_cert_min_validity_days | default(30) }} days. Use cca_splunk_cert_min_validity_days
           to override the default.
       when:
         - cca_splunk_cert_enrollment_method != 'selfsigned'
         - cert_info_result is defined
+        - cert_info_result.valid_at is defined
 
     - name: "Set fact for cert file names and concatenation order of cert of type {{ cert_type }}"
       ansible.builtin.set_fact:

--- a/templates/infrastructure_template/.storage/settings
+++ b/templates/infrastructure_template/.storage/settings
@@ -1,5 +1,5 @@
 [default]
-cca_infrastructure_storage_settings_file_version="2025.3.1"
+cca_infrastructure_storage_settings_file_version="2025.3.1.2"
 repo_type=infrastructure
 CcaRepo=cca_for_splunk
 EnforceMultiplexer=false

--- a/templates/infrastructure_template/cca_ctrl
+++ b/templates/infrastructure_template/cca_ctrl
@@ -78,7 +78,7 @@ else
 fi
 
 WhiptailHight=30
-BackTitle="   $(hostname -s) - CCA for Splunk $(date +'%Y') v2025.3.1"
+BackTitle="   $(hostname -s) - CCA for Splunk $(date +'%Y') v2025.3.1.2"
 CookieFile="${ScriptPath}/.cookie"
 LicenseFile=~/clones/cca_for_splunk/LICENSE
 InfoFile=~/clones/cca_for_splunk/RELEASE_NOTES.txt

--- a/templates/infrastructure_template/environments/ENVIRONMENT_NAME/group_vars/all/linux
+++ b/templates/infrastructure_template/environments/ENVIRONMENT_NAME/group_vars/all/linux
@@ -1,6 +1,6 @@
 # Version parameter is used to validate this file
 # against cca_for_splunk framework requirements.
-cca_infrastructure_linux_file_version: '2025.3.1'
+cca_infrastructure_linux_file_version: '2025.3.1.2'
 
 external_bootstrap_pre_roles:
 external_bootstrap_roles:
@@ -20,6 +20,7 @@ cca_baseline_software:
   - '{{"openssh-client" if package_manager == "apt" else None }}'
   - '{{"dnsutils" if package_manager == "apt" else "bind-utils" }}'
   - '{{"acl" if package_manager == "apt" else None }}'
+  - 'jq'
 control:
   linux_configuration:
     splunk_user: true

--- a/templates/onboarding_template/.storage/settings
+++ b/templates/onboarding_template/.storage/settings
@@ -1,5 +1,5 @@
 [default]
-cca_onboarding_storage_settings_file_version="2025.3.1"
+cca_onboarding_storage_settings_file_version="2025.3.1.2"
 repo_type=onboarding
 CcaRepo=cca_for_splunk
 EnforceMultiplexer=false

--- a/templates/onboarding_template/cca_ctrl
+++ b/templates/onboarding_template/cca_ctrl
@@ -78,7 +78,7 @@ else
 fi
 
 WhiptailHight=30
-BackTitle="   $(hostname -s) - CCA for Splunk $(date +'%Y') v2025.3.1"
+BackTitle="   $(hostname -s) - CCA for Splunk $(date +'%Y') v2025.3.1.2"
 CookieFile="${ScriptPath}/.cookie"
 LicenseFile=~/clones/cca_for_splunk/LICENSE
 InfoFile=~/clones/cca_for_splunk/RELEASE_NOTES.txt

--- a/templates/onboarding_template/environments/ENVIRONMENT_NAME/group_vars/all/onboarding
+++ b/templates/onboarding_template/environments/ENVIRONMENT_NAME/group_vars/all/onboarding
@@ -14,6 +14,8 @@ selected_shcluster_apps_sourcedir: 'shcluster/selectable'
 manager_apps_sourcedir: '{{ cluster_manager_config_bundle_dir }}/{{ environment_name }}/{{ cluster_label }}'
 selected_manager_apps_sourcedir: '{{ cluster_manager_config_bundle_dir }}/selectable'
 
+cca_local_tmp_dir: '{{ lookup("env", "HOME", default="/tmp") }}/cca_tmp'
+
 # Optional variables for customizing source directory paths
 # Uncomment and update with absolute paths
 # manager_apps_absolute_sourcedir:


### PR DESCRIPTION
```
    2025.3.1.2
              - Enhanced deployment server reload state file cleanup during Splunk restarts and server reboots.
                Ensures both restart and reload state files are properly cleaned up on deployment servers.
              - Updated deprecated ansible environment variable ANSIBLE_STDOUT_CALLBACK=yaml. Use these variables
                instead, set them in your ~/.profile_local file on your manager server.
                    export ANSIBLE_STDOUT_CALLBACK=ansible.builtin.default
                    export ANSIBLE_CALLBACK_RESULT_FORMAT=yaml
                    export ANSIBLE_CALLBACK_FORMAT_PRETTY=true

              Bug fixes:
                * Corrected an issue with onboarding groups that use the dest_dir option. Incorrect variable used
                  in directory references.
                * Include jq in the list of cca_baseline_software, defined in group_vars/all/linux. Copy settings from
                  the infrastructure group_vars/all/linux template file.
                * Improved robustness of rsync status classification filters to handle empty lists and invalid input.
                * Fixed certificate validation error handling with proper default values for undefined variables.
                * Corrected onboarding task variable references and improved ansible-lint compliance across multiple files.


    2025.3.1.1
              - Added configurable temporary directory option for rsync operations during app staging.
                Set cca_local_tmp_dir to override default /tmp/cca_tmp directory location, update
                your local settings from the updated file in templates directory
                onboarding_templates/environment/ENVIRONMENT_NAME/group_vars/all/onboarding
```